### PR TITLE
remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   "author": "John Hiesey",
   "license": "MIT",
   "dependencies": {
+    "mp4box": "git://github.com/jhiesey/mp4box.js.git#nodified"
+  },
+  "devDependencies": {
     "browserify": "^9.0.3",
-    "http-server": "^0.7.5",
-    "inherits": "^2.0.1",
-    "mp4box": "git://github.com/jhiesey/mp4box.js.git#nodified",
-    "webtorrent": "^0.29.3"
+    "http-server": "^0.8.0"
   }
 }


### PR DESCRIPTION
If `webtorrent` ever depends on `videostream` there will be a circular dependency! This fixes that up ;-)