### PR TITLE
Use https:// url to fix Windows usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^2.2.0",
-    "mp4box": "git://github.com/jhiesey/mp4box.js.git#nodified"
+    "mp4box": "https://github.com/jhiesey/mp4box.js.git#nodified"
   },
   "devDependencies": {
     "browserify": "^9.0.3",


### PR DESCRIPTION
I believe that Windows can't handle `git+ssh://` urls in npm
dependencies.

More info: https://github.com/feross/webtorrent/issues/393