### PR TITLE
Node compatibility

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -1,9 +1,10 @@
 var videostream = require('./videostream');
 var WebTorrent = require('webtorrent');
 
-// This demo uses WebTorrent (https://github.com/feross/webtorrent)
+// This demo uses WebTorrent (https://webtorrent.io)
 var client = new WebTorrent();
 
+// Sintel torrent from webtorrent.io (https://webtorrent.io/torrents/sintel.torrent)
 var infoHash = '6a9759bffd5c0af65319979fb7832189f4f3c35d';
 
 client.add({

--- a/demo.js
+++ b/demo.js
@@ -3,8 +3,8 @@ var WebTorrent = require('webtorrent');
 
 // This demo uses WebTorrent (https://github.com/feross/webtorrent)
 var client = new WebTorrent();
-// This hash is for the file at http://mirrorblender.top-ix.org/movies/sintel-1024-surround.mp4
-var infoHash = 'a54c3ee75cb901001e46da2072ed7bfde7a5374e';
+
+var infoHash = '6a9759bffd5c0af65319979fb7832189f4f3c35d';
 
 client.add({
 	infoHash: infoHash,

--- a/videostream.js
+++ b/videostream.js
@@ -180,7 +180,7 @@ module.exports = function (file, mediaElem, opts) {
 			// lots of 'data' event blocking the UI
 			stream.pause();
 
-			var arrayBuffer = data.toArrayBuffer(); // TODO: avoid copy
+			var arrayBuffer = new Buffer(data).buffer; // TODO: avoid copy
 			arrayBuffer.fileStart = requestOffset;
 			requestOffset += arrayBuffer.byteLength;
 			var nextOffset;


### PR DESCRIPTION
Node removed the buffer.toArrayBuffer() API sometime during node 0.11.
Relying on it makes videostream not work in node.js or Electron.

This is equivalent since it’s what feross/buffer is doing internally.

I will make an issue to remove buffer.toArrayBuffer() from
feross/buffer so they have parity.