### PR TITLE
On error, expose `mediasource.detailedError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,25 @@ var exampleFile = {
 	}
 }
 
-var videostream = require('videostream');
+var VideoStream = require('videostream');
 
-var video = document.createElement('video');
-videostream(exampleFile, video);
+var elem = document.createElement('video');
+var videostream = VideoStream(exampleFile, elem);
+
+elem.addEventListener('error', function () {
+  // listen for errors on the video/audio element directly
+  var errorCode = elem.error
+  var detailedError = videostream.detailedError
+  // videostream.detailedError will often have a more detailed error message
+})
 ```
+
+### Errors
+
+Handle errors by listening to the `'error'` event on the `<video>` or `<audio>` tag.
+
+Some (but not all) errors will also cause `videostream.detailedError` to be set to
+an error value that has a more informative error message.
 
 ## License
 

--- a/videostream.js
+++ b/videostream.js
@@ -10,6 +10,8 @@ function VideoStream (file, mediaElem, opts) {
 	if (!(this instanceof VideoStream)) return new VideoStream(file, mediaElem, opts)
 	opts = opts || {}
 
+	self.detailedError = null
+
 	self._elem = mediaElem
 	self._elemWrapper = new MediaElementWrapper(mediaElem)
 	self._waitingFired = false
@@ -21,6 +23,7 @@ function VideoStream (file, mediaElem, opts) {
 	}
 
 	self._onError = function (err) {
+		self.detailedError = self._elemWrapper.detailedError
 		self.destroy() // don't pass err though so the user doesn't need to listen for errors
 	}
 	self._onWaiting = function () {


### PR DESCRIPTION
Also, update the readme with error-handling information.