### PR TITLE
Fix autoplay not working in Firefox and Chromium

### DIFF
--- a/videostream.js
+++ b/videostream.js
@@ -34,6 +34,8 @@ function VideoStream (file, mediaElem, opts) {
 			self._pump()
 		}
 	}
+	if(self._elem.autoplay)
+		self._elem.preload = "auto";
 	self._elem.addEventListener('waiting', self._onWaiting)
 	self._elem.addEventListener('error', self._onError)
 }


### PR DESCRIPTION
This can be seen with the example in the example folder with Firefox 52.7.2 ESR and Chromium 64.0.3282.119. Firefox an chrome won't create a waiting event if autoplay is set but preload isn't, which cases _onWaiting to not be called and the video to not autoplay. _onWaiting could be called directly, but this commit will just set preload to auto if autoplay is set, which will cause the browser to generate a waiting event and thus _onWaiting to be called.