### PR TITLE
fix: don't pipe to multiple destinations

### DIFF
--- a/mp4-remuxer.js
+++ b/mp4-remuxer.js
@@ -54,7 +54,6 @@ class MP4Remuxer extends EventEmitter {
       }
     }
     this._decoder.on('box', boxHandler)
-
   }
 
   _processMoov (moov) {
@@ -309,11 +308,10 @@ class MP4Remuxer extends EventEmitter {
     })
 
     if (startOffset >= 0) {
-      const fileStream = this._fileStream = this._file.createReadStream({
-        start: startOffset
-      })
-
       this._tracks.forEach(track => {
+        const fileStream = this._fileStream = this._file.createReadStream({
+          start: startOffset
+        })
         track.inStream = new RangeSliceStream(startOffset, {
           // Allow up to a 10MB offset between audio and video,
           // which should be fine for any reasonable interleaving


### PR DESCRIPTION
This fixes an issue where `videostream` would pipe a single stream to multiple destinations. This is fine for node streams, but is incompatible with `streamx` for web